### PR TITLE
Reset the recordings model after creating the directory

### DIFF
--- a/src/harbour-recorder.cpp
+++ b/src/harbour-recorder.cpp
@@ -43,6 +43,7 @@ int main(int argc, char *argv[])
 
     RecordingsModel sourceModel;
     sourceModel.setRecorder(&recorder);
+    recorder.setRecordingsModel(&sourceModel);
     QSortFilterProxyModel recordingsModel;
     recordingsModel.setSourceModel(&sourceModel);
     recordingsModel.setSortRole(RecordingsModel::Modified);

--- a/src/recorder.cpp
+++ b/src/recorder.cpp
@@ -1,4 +1,5 @@
 #include "recorder.h"
+#include "recordingsmodel.h"
 #include <QDir>
 #include <QDateTime>
 #include <QUrl>
@@ -30,6 +31,21 @@ Recorder::Recorder(QObject *parent) :
     {
         mSdCardPath = media.absoluteFilePath(mediaEntries.first());
     }
+}
+
+RecordingsModel *Recorder::recordingsModel() const
+{
+    return mRecordingsModel;
+}
+
+void Recorder::setRecordingsModel(RecordingsModel *recordingsModel)
+{
+    if (mRecordingsModel == recordingsModel)
+    {
+        return;
+    }
+
+    mRecordingsModel = recordingsModel;
 }
 
 QString Recorder::location() const
@@ -108,9 +124,14 @@ void Recorder::startRecording()
     }
 
     QDir location(this->location());
-    if(!location.exists() && !location.mkpath("."))
-    {
-        emit this->pathCreationFailed();
+    if(!location.exists()) {
+        if (!location.mkpath(".")) {
+            emit this->pathCreationFailed();
+        }
+        else {
+            // Reset the model after path creation to show the new file.
+            this->recordingsModel()->resetModel();
+        }
     }
 
     QAudioEncoderSettings encoderSettings;

--- a/src/recorder.h
+++ b/src/recorder.h
@@ -5,6 +5,7 @@
 #include <QSettings>
 #include <QSortFilterProxyModel>
 
+class RecordingsModel;
 
 class Recorder : public QAudioRecorder
 {
@@ -29,6 +30,9 @@ public:
     Q_ENUM(Codec)
 
     explicit Recorder(QObject* parent = 0);
+
+    RecordingsModel *recordingsModel() const;
+    void setRecordingsModel(RecordingsModel *recordingsModel);
 
     Q_INVOKABLE bool shouldMigrate() const;
     Q_INVOKABLE bool migrate();
@@ -74,6 +78,7 @@ private:
     static const QString defaultStoragePath;
 
     QHash<Codec, CodecSetting> codecSettingsMap;
+    RecordingsModel *mRecordingsModel;
     QSettings settings;
     QString mSdCardPath;
 };

--- a/src/recordingsmodel.h
+++ b/src/recordingsmodel.h
@@ -27,12 +27,12 @@ public:
 
     Recorder *recorder() const;
     void setRecorder(Recorder *recorder);
+    void resetModel();
 
     Q_INVOKABLE bool contains(const QString &filePath) const;
 
 private slots:
     void scanRecords(const QString &path);
-    void resetModel();
 
 private:
     static QString sectionName(const QDate &modDate);

--- a/translations/harbour-recorder-el.ts
+++ b/translations/harbour-recorder-el.ts
@@ -136,7 +136,7 @@
 <context>
     <name>Recorder</name>
     <message>
-        <location filename="../src/recorder.cpp" line="130"/>
+        <location filename="../src/recorder.cpp" line="150"/>
         <source>recording</source>
         <translation>ηχογραφείται</translation>
     </message>

--- a/translations/harbour-recorder-es.ts
+++ b/translations/harbour-recorder-es.ts
@@ -137,7 +137,7 @@ Tarjeta SD</translation>
 <context>
     <name>Recorder</name>
     <message>
-        <location filename="../src/recorder.cpp" line="130"/>
+        <location filename="../src/recorder.cpp" line="150"/>
         <source>recording</source>
         <translation>grabando</translation>
     </message>

--- a/translations/harbour-recorder-fi.ts
+++ b/translations/harbour-recorder-fi.ts
@@ -136,7 +136,7 @@
 <context>
     <name>Recorder</name>
     <message>
-        <location filename="../src/recorder.cpp" line="130"/>
+        <location filename="../src/recorder.cpp" line="150"/>
         <source>recording</source>
         <translation>Äänitallenne</translation>
     </message>

--- a/translations/harbour-recorder-fr.ts
+++ b/translations/harbour-recorder-fr.ts
@@ -136,7 +136,7 @@
 <context>
     <name>Recorder</name>
     <message>
-        <location filename="../src/recorder.cpp" line="130"/>
+        <location filename="../src/recorder.cpp" line="150"/>
         <source>recording</source>
         <translation>enregistrement</translation>
     </message>

--- a/translations/harbour-recorder-hu.ts
+++ b/translations/harbour-recorder-hu.ts
@@ -136,7 +136,7 @@
 <context>
     <name>Recorder</name>
     <message>
-        <location filename="../src/recorder.cpp" line="130"/>
+        <location filename="../src/recorder.cpp" line="150"/>
         <source>recording</source>
         <translation>felvétel</translation>
     </message>

--- a/translations/harbour-recorder-it.ts
+++ b/translations/harbour-recorder-it.ts
@@ -136,7 +136,7 @@
 <context>
     <name>Recorder</name>
     <message>
-        <location filename="../src/recorder.cpp" line="130"/>
+        <location filename="../src/recorder.cpp" line="150"/>
         <source>recording</source>
         <translation>registrazione</translation>
     </message>

--- a/translations/harbour-recorder-nl.ts
+++ b/translations/harbour-recorder-nl.ts
@@ -136,7 +136,7 @@
 <context>
     <name>Recorder</name>
     <message>
-        <location filename="../src/recorder.cpp" line="130"/>
+        <location filename="../src/recorder.cpp" line="150"/>
         <source>recording</source>
         <translation>opname</translation>
     </message>

--- a/translations/harbour-recorder-nl_BE.ts
+++ b/translations/harbour-recorder-nl_BE.ts
@@ -136,7 +136,7 @@
 <context>
     <name>Recorder</name>
     <message>
-        <location filename="../src/recorder.cpp" line="130"/>
+        <location filename="../src/recorder.cpp" line="150"/>
         <source>recording</source>
         <translation>opname</translation>
     </message>

--- a/translations/harbour-recorder-pt_BR.ts
+++ b/translations/harbour-recorder-pt_BR.ts
@@ -136,7 +136,7 @@
 <context>
     <name>Recorder</name>
     <message>
-        <location filename="../src/recorder.cpp" line="130"/>
+        <location filename="../src/recorder.cpp" line="150"/>
         <source>recording</source>
         <translation>Gravando</translation>
     </message>

--- a/translations/harbour-recorder-ru.ts
+++ b/translations/harbour-recorder-ru.ts
@@ -136,7 +136,7 @@
 <context>
     <name>Recorder</name>
     <message>
-        <location filename="../src/recorder.cpp" line="130"/>
+        <location filename="../src/recorder.cpp" line="150"/>
         <source>recording</source>
         <translation>запись</translation>
     </message>

--- a/translations/harbour-recorder-sv.ts
+++ b/translations/harbour-recorder-sv.ts
@@ -136,7 +136,7 @@
 <context>
     <name>Recorder</name>
     <message>
-        <location filename="../src/recorder.cpp" line="130"/>
+        <location filename="../src/recorder.cpp" line="150"/>
         <source>recording</source>
         <translation>spelar in</translation>
     </message>

--- a/translations/harbour-recorder-zh_CN.ts
+++ b/translations/harbour-recorder-zh_CN.ts
@@ -136,7 +136,7 @@
 <context>
     <name>Recorder</name>
     <message>
-        <location filename="../src/recorder.cpp" line="130"/>
+        <location filename="../src/recorder.cpp" line="150"/>
         <source>recording</source>
         <translation>录制中</translation>
     </message>

--- a/translations/harbour-recorder-zh_TW.ts
+++ b/translations/harbour-recorder-zh_TW.ts
@@ -136,7 +136,7 @@
 <context>
     <name>Recorder</name>
     <message>
-        <location filename="../src/recorder.cpp" line="130"/>
+        <location filename="../src/recorder.cpp" line="150"/>
         <source>recording</source>
         <translation>錄音中</translation>
     </message>


### PR DESCRIPTION
I noticed that on first run (ie. when the save directory doesn't exist when the app is started) any recorded files are not shown, because the recordings model only watches the directory if it existed when initialising the model.

This patch adds a call to resetModel() if the path is created in the start of recording.